### PR TITLE
Update ts-monads and lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
             "license": "MIT",
             "dependencies": {
                 "@zaptic-external/ts-monads": "1.2.1",
-                "lodash.memoize": "4.1.2",
+                "lodash": "^4.17.21",
                 "pg": "8.5.1",
                 "pg-query-stream": "4.1.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.0",
                 "@types/chai-as-promised": "^7.1.4",
-                "@types/lodash.memoize": "4.1.6",
+                "@types/lodash": "^4.14.202",
                 "@types/mocha": "^9.1.0",
                 "@types/pg": "7.14.11",
                 "chai": "4.3.4",
@@ -44,19 +44,10 @@
             }
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.168",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-            "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+            "version": "4.14.202",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
             "dev": true
-        },
-        "node_modules/@types/lodash.memoize": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz",
-            "integrity": "sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
         },
         "node_modules/@types/mocha": {
             "version": "9.1.0",
@@ -720,11 +711,6 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "node_modules/lodash.memoize": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -1431,19 +1417,10 @@
             }
         },
         "@types/lodash": {
-            "version": "4.14.168",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-            "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+            "version": "4.14.202",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
             "dev": true
-        },
-        "@types/lodash.memoize": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz",
-            "integrity": "sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==",
-            "dev": true,
-            "requires": {
-                "@types/lodash": "*"
-            }
         },
         "@types/mocha": {
             "version": "9.1.0",
@@ -1937,11 +1914,6 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "lodash.memoize": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
         },
         "log-symbols": {
             "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
-                "@zaptic-external/ts-monads": "1.2.0",
+                "@zaptic-external/ts-monads": "1.2.1",
                 "lodash.memoize": "4.1.2",
                 "pg": "8.5.1",
                 "pg-query-stream": "4.1.0"
@@ -88,12 +88,11 @@
             "dev": true
         },
         "node_modules/@zaptic-external/ts-monads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@zaptic-external/ts-monads/-/ts-monads-1.2.0.tgz",
-            "integrity": "sha512-Wad2YggQVFhequ7AUkF9mTTG8Q9kq2B1jFuQ5lyZVABndZMyi4kFPT+Qn/BH8mCpPke/L9FoHZIQ6u979r+Ecg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@zaptic-external/ts-monads/-/ts-monads-1.2.1.tgz",
+            "integrity": "sha512-2B2r0GdmtP4Nxg9ed930cHQZq2Tp0SxOkLvs1EnK+0XX2oPx6RUBLXIdV6QU+60+pPEtwQZly9Uuclj6XZF+aQ==",
             "dependencies": {
-                "lodash.omit": "4.5.0",
-                "lodash.pick": "4.4.0"
+                "lodash": "^4.17.21"
             }
         },
         "node_modules/ansi-colors": {
@@ -717,20 +716,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-        },
-        "node_modules/lodash.omit": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-            "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-        },
-        "node_modules/lodash.pick": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -1469,12 +1463,11 @@
             "dev": true
         },
         "@zaptic-external/ts-monads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@zaptic-external/ts-monads/-/ts-monads-1.2.0.tgz",
-            "integrity": "sha512-Wad2YggQVFhequ7AUkF9mTTG8Q9kq2B1jFuQ5lyZVABndZMyi4kFPT+Qn/BH8mCpPke/L9FoHZIQ6u979r+Ecg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@zaptic-external/ts-monads/-/ts-monads-1.2.1.tgz",
+            "integrity": "sha512-2B2r0GdmtP4Nxg9ed930cHQZq2Tp0SxOkLvs1EnK+0XX2oPx6RUBLXIdV6QU+60+pPEtwQZly9Uuclj6XZF+aQ==",
             "requires": {
-                "lodash.omit": "4.5.0",
-                "lodash.pick": "4.4.0"
+                "lodash": "^4.17.21"
             }
         },
         "ansi-colors": {
@@ -1928,20 +1921,15 @@
                 "p-locate": "^5.0.0"
             }
         },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-        },
-        "lodash.omit": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-            "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-        },
-        "lodash.pick": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
         },
         "log-symbols": {
             "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -538,9 +538,9 @@
             }
         },
         "node_modules/get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true,
             "engines": {
                 "node": "*"
@@ -743,9 +743,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -755,9 +755,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-            "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+            "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
             "dev": true,
             "dependencies": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -773,9 +773,9 @@
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
-                "minimatch": "3.0.4",
+                "minimatch": "4.2.1",
                 "ms": "2.1.3",
-                "nanoid": "3.2.0",
+                "nanoid": "3.3.1",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
@@ -797,6 +797,18 @@
                 "url": "https://opencollective.com/mochajs"
             }
         },
+        "node_modules/mocha/node_modules/minimatch": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+            "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -804,9 +816,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -1794,9 +1806,9 @@
             "dev": true
         },
         "get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true
         },
         "glob": {
@@ -1942,18 +1954,18 @@
             }
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
         },
         "mocha": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-            "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+            "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -1969,9 +1981,9 @@
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
-                "minimatch": "3.0.4",
+                "minimatch": "4.2.1",
                 "ms": "2.1.3",
-                "nanoid": "3.2.0",
+                "nanoid": "3.3.1",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
@@ -1980,6 +1992,17 @@
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+                    "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
             }
         },
         "ms": {
@@ -1989,9 +2012,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true
         },
         "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     },
     "dependencies": {
         "@zaptic-external/ts-monads": "1.2.1",
-        "lodash.memoize": "4.1.2",
+        "lodash": "^4.17.21",
         "pg": "8.5.1",
         "pg-query-stream": "4.1.0"
     },
     "devDependencies": {
         "@types/chai": "^4.3.0",
         "@types/chai-as-promised": "^7.1.4",
-        "@types/lodash.memoize": "4.1.6",
+        "@types/lodash": "^4.14.202",
         "@types/mocha": "^9.1.0",
         "@types/pg": "7.14.11",
         "chai": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "tsc": "tsc"
     },
     "dependencies": {
-        "@zaptic-external/ts-monads": "1.2.0",
+        "@zaptic-external/ts-monads": "1.2.1",
         "lodash.memoize": "4.1.2",
         "pg": "8.5.1",
         "pg-query-stream": "4.1.0"

--- a/src/typedQuery.ts
+++ b/src/typedQuery.ts
@@ -1,4 +1,4 @@
-import memoize from 'lodash.memoize'
+import { memoize } from 'lodash'
 
 export type Pivotted<T> = {
     [P in keyof T]-?: Array<T[P]>


### PR DESCRIPTION
Update to the latest version of `@zaptic-external/ts-monads` and `lodash` to avoid reported security issues.